### PR TITLE
Enhance prompt context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,104 @@
+use std::{fs, path::Path};
+
+/// ディレクトリ表示名の解決ロジック
+/// current: 現在のディレクトリ, base: 起動時のディレクトリ
+pub fn resolve_display_dir(current: &Path, base: &Path) -> Option<String> {
+    if current == base {
+        Some(".".to_string())
+    } else {
+        Some(
+            current
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(".")
+                .to_string(),
+        )
+    }
+}
+
+// --- Git branch 取得ロジック---
+/// ファイルの中身からブランチ名またはハッシュを抽出する純粋関数
+fn parse_git_head(content: &str) -> Option<String> {
+    let content = content.trim();
+
+    // "ref: refs/heads/main" の形式なら "main" を返す
+    if let Some(branch) = content.strip_prefix("ref: refs/heads/") {
+        return Some(branch.to_string());
+    }
+
+    // Detached HEAD (ハッシュ値) の場合は先頭7文字を返す
+    if content.len() >= 7 {
+        return Some(content[..7].to_string());
+    }
+
+    None
+}
+
+/// カレントディレクトリから遡って .git/HEAD を探し、ブランチ名を返す
+pub fn get_git_branch(cwd: &Path) -> Option<String> {
+    let mut current = cwd;
+
+    loop {
+        let git_dir = current.join(".git");
+        let head_path = git_dir.join("HEAD");
+
+        if head_path.exists() {
+            // HEADファイルを読み込む
+            if let Ok(content) = fs::read_to_string(head_path) {
+                return parse_git_head(&content);
+            }
+            return None;
+        }
+
+        match current.parent() {
+            Some(p) => current = p,
+            None => break,
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- resolve_display_dir のテスト ---
+
+    #[test]
+    fn test_display_dir_same() {
+        let base = std::path::PathBuf::from("/home/user/project");
+        let current = std::path::PathBuf::from("/home/user/project");
+
+        assert_eq!(resolve_display_dir(&current, &base), Some(".".to_string()));
+    }
+
+    #[test]
+    fn test_display_dir_diff() {
+        let base = std::path::PathBuf::from("/home/user/project");
+        let current = std::path::PathBuf::from("/home/user/project/src");
+
+        // "src" が返るはず
+        assert_eq!(
+            resolve_display_dir(&current, &base),
+            Some("src".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_git_head_branch() {
+        let content = "ref: refs/heads/main\n";
+        assert_eq!(parse_git_head(content), Some("main".to_string()));
+    }
+
+    #[test]
+    fn test_parse_git_head_detached() {
+        let content = "a1b2c3d4e5f67890abcdef1234567890abcdef12";
+        assert_eq!(parse_git_head(content), Some("a1b2c3d".to_string()));
+    }
+
+    #[test]
+    fn test_parse_git_head_invalid() {
+        let content = "short";
+        assert_eq!(parse_git_head(content), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
+mod context;
 mod parser;
 mod with_helper;
 
+use context::*;
 use parser::*;
 use rustyline::{Cmd, Editor, KeyCode, Modifiers, Movement, Result, error::ReadlineError};
 use std::{

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,4 @@
-use std::{
-    fs,
-    option::Option::{None, Some},
-    path::Path,
-};
+use std::option::Option::{None, Some};
 
 #[derive(Debug, PartialEq)]
 pub enum CommandAction {
@@ -85,64 +81,6 @@ pub fn parse_cmd(line: &str, target_cmd: Option<&str>) -> CommandAction {
             }
         }
     }
-}
-
-/// ディレクトリ表示名の解決ロジック
-/// current: 現在のディレクトリ, base: 起動時のディレクトリ
-pub fn resolve_display_dir(current: &Path, base: &Path) -> Option<String> {
-    if current == base {
-        Some(".".to_string())
-    } else {
-        Some(
-            current
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or(".")
-                .to_string(),
-        )
-    }
-}
-
-// --- Git branch 取得ロジック---
-/// ファイルの中身からブランチ名またはハッシュを抽出する純粋関数
-fn parse_git_head(content: &str) -> Option<String> {
-    let content = content.trim();
-
-    // "ref: refs/heads/main" の形式なら "main" を返す
-    if let Some(branch) = content.strip_prefix("ref: refs/heads/") {
-        return Some(branch.to_string());
-    }
-
-    // Detached HEAD (ハッシュ値) の場合は先頭7文字を返す
-    if content.len() >= 7 {
-        return Some(content[..7].to_string());
-    }
-
-    None
-}
-
-/// カレントディレクトリから遡って .git/HEAD を探し、ブランチ名を返す
-pub fn get_git_branch(cwd: &Path) -> Option<String> {
-    let mut current = cwd;
-
-    loop {
-        let git_dir = current.join(".git");
-        let head_path = git_dir.join("HEAD");
-
-        if head_path.exists() {
-            // HEADファイルを読み込む
-            if let Ok(content) = fs::read_to_string(head_path) {
-                return parse_git_head(&content);
-            }
-            return None;
-        }
-
-        match current.parent() {
-            Some(p) => current = p,
-            None => break,
-        }
-    }
-    None
 }
 
 // テストコード
@@ -241,45 +179,5 @@ mod tests {
         // input: "" (空行)
         let action = parse_cmd("", None);
         assert_eq!(action, CommandAction::DoNothing);
-    }
-
-    // --- resolve_display_dir のテスト ---
-
-    #[test]
-    fn test_display_dir_same() {
-        let base = std::path::PathBuf::from("/home/user/project");
-        let current = std::path::PathBuf::from("/home/user/project");
-
-        assert_eq!(resolve_display_dir(&current, &base), Some(".".to_string()));
-    }
-
-    #[test]
-    fn test_display_dir_diff() {
-        let base = std::path::PathBuf::from("/home/user/project");
-        let current = std::path::PathBuf::from("/home/user/project/src");
-
-        // "src" が返るはず
-        assert_eq!(
-            resolve_display_dir(&current, &base),
-            Some("src".to_string())
-        );
-    }
-
-    #[test]
-    fn test_parse_git_head_branch() {
-        let content = "ref: refs/heads/main\n";
-        assert_eq!(parse_git_head(content), Some("main".to_string()));
-    }
-
-    #[test]
-    fn test_parse_git_head_detached() {
-        let content = "a1b2c3d4e5f67890abcdef1234567890abcdef12";
-        assert_eq!(parse_git_head(content), Some("a1b2c3d".to_string()));
-    }
-
-    #[test]
-    fn test_parse_git_head_invalid() {
-        let content = "short";
-        assert_eq!(parse_git_head(content), None);
     }
 }

--- a/src/with_helper.rs
+++ b/src/with_helper.rs
@@ -27,7 +27,7 @@ impl Highlighter for WithHelper {
                     let styled_content = if let Some(sep_idx) = content_inside.find(": ") {
                         // "src : main" のように区切りがある場合
                         let path_part = &content_inside[0..sep_idx];
-                        let branch_part = &content_inside[sep_idx + 2..]; // " : " は3文字
+                        let branch_part = &content_inside[sep_idx + 2..]; // ": " は2文字
 
                         format!(
                             "{}{}{}{}{}: {}{}{}",


### PR DESCRIPTION
## 概要
Closes #5

ユーザーが現在のコンテキスト（場所、Gitの状態）を把握しやすくするため、プロンプトの表示情報を強化しました。
カレントディレクトリとGitのブランチ名を表示するように変更しています。

## 変更内容

### 1. プロンプト表示の変更
プロンプトのフォーマットを以下のように変更しました。

- **変更前**: `git [.] >`
- **変更後**: `(.: feature-branch) git >`
    - ディレクトリ名とブランチ名を `(path: branch)` の形式で表示
    - `with_helper.rs` により、パス（緑）とブランチ（マゼンタ）を色分けして視認性を向上

### 2. アーキテクチャの整理 (`context.rs` の作成)
これまで `parser.rs` や `main.rs` に混在していた「環境情報の取得ロジック」を、新設した **`context.rs`** に分離・集約しました。
これにより、`parser.rs` はコマンド解析のみ、`context.rs` は環境情報の提供のみ、と責務が明確になりました。

### 3. 軽量なGitブランチ取得
プロンプト表示はコマンド実行のたびに行われるため、パフォーマンスを最優先しました。
`git2` クレートや外部の `git` コマンド呼び出しを使用せず、`.git/HEAD` ファイルを直接パースする実装にすることで、動作の軽量化を図っています。

## 動作確認
- [x] 通常のディレクトリでの表示確認
- [x] Gitリポジトリ内（通常ブランチ）での表示確認
- [x] Gitリポジトリ内（Detached HEAD状態）でのハッシュ表示確認
- [x] `context.rs`, `parser.rs` の単体テスト通過