### PR TITLE
feat: Rustylineによるファイル名補完の実装

### DIFF
--- a/src/with_helper.rs
+++ b/src/with_helper.rs
@@ -1,16 +1,36 @@
-use rustyline::{Completer, Helper, Hinter, Validator, highlight::Highlighter};
+use rustyline::{
+    Context, Helper, Hinter, Validator,
+    completion::{Completer, FilenameCompleter, Pair},
+    highlight::Highlighter,
+};
 use std::borrow::Cow;
 
 // --- Rustylineのヘルパー設定 ---
-#[derive(Helper, Completer, Hinter, Validator)]
-pub struct WithHelper {}
+#[derive(Helper, Hinter, Validator)]
+pub struct WithHelper {
+    pub completer: FilenameCompleter,
+}
 
 // プロンプトの色付け用
 const COLOR_GREEN: &str = "\x1b[32m";
 const COLOR_CYAN: &str = "\x1b[36m";
-const COLOR_MAGENTA: &str = "\x1b[35m"; // ★ 追加: ブランチ用
+const COLOR_MAGENTA: &str = "\x1b[35m";
 const STYLE_BOLD: &str = "\x1b[1m";
 const STYLE_RESET: &str = "\x1b[0m";
+
+impl Completer for WithHelper {
+    type Candidate = Pair;
+
+    fn complete(
+        &self, // FIXME should be `&mut self`
+        line: &str,
+        pos: usize,
+        ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        // 処理を標準のFilenameCompleterに丸投げ（委譲）する
+        self.completer.complete(line, pos, ctx)
+    }
+}
 
 impl Highlighter for WithHelper {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(


### PR DESCRIPTION
## 概要
Closes #6 

v0.3.0 の要件である「ファイル名補完」機能を実装しました。
`rustyline` 標準の `FilenameCompleter` を利用することで、CLI上で Tab キーによるファイル・ディレクトリ名の補完が可能になります。

## 変更点
- **`src/with_helper.rs`**:
    - `WithHelper` 構造体から `#[derive(Completer)]` を削除し、手動実装に変更。
    - 内部に `FilenameCompleter` を保持し、処理を委譲するように修正。
- **`src/main.rs`**:
    - `Editor` の初期化時に `config` を適用。
    - `CompletionType::List` を設定し、Tab連打で候補一覧が表示されるように変更（`ls` コマンドのような挙動）。

## 挙動
- **入力補完**: コマンド入力中に Tab キーを押すと、カレントディレクトリのファイル名を補完します。
- **候補一覧**: 候補が複数ある場合、Tab キーを連打（2回）すると候補リストが表示されます。
- **対象**: `with` 単体起動時、および `with <cmd>` 実行時のどちらでも有効です。

## 動作確認手順
1. `cargo run` で起動する。
2. `ls C` (または存在するファイル名の先頭) を入力し、Tab キーを押して補完されることを確認。
3. `ls s` (複数候補がある状態) を入力し、Tab キーを2回押して一覧が表示されることを確認。
4. スペースを含むファイル名が正しくエスケープされて補完されることを確認。

## 備考
- 今回のスコープは「ファイルパスの補完」のみです。
- Gitサブコマンド等の補完（例: `git stat...` -> `status`）は v0.4.0 以降で対応予定です。